### PR TITLE
Optimize Base32.encode by not creating intermediate Array

### DIFF
--- a/src/base32.cr
+++ b/src/base32.cr
@@ -6,16 +6,18 @@ module Base32
   def self.encode(number : Int) : String
     return "0" if number == 0_i64
 
-    array = Deque(Char).new(13) # max spaces for Int64::MAX
-
-    while number > 0_i64
-      index  = number %  32_i64 # divmod is a bit slow
-      number = number >> 5      # number / 32
-      array << ENCODE_MAP[index]
+    bytesize = 0
+    each_encode_index(number) do
+      bytesize += 1
     end
 
-    return String.build(capacity: array.size) do |s|
-      array.reverse_each{|char| s << char}
+    String.new(bytesize) do |buffer|
+      ptr = buffer + bytesize - 1
+      each_encode_index(number) do |index|
+        ptr.value = ENCODE_MAP[index].ord.to_u8
+        ptr -= 1
+      end
+      {bytesize, bytesize}
     end
   end
 
@@ -26,5 +28,13 @@ module Base32
       total = total * 32_i64 + value
     end
     return total
+  end
+
+  private def self.each_encode_index(number : Int)
+    while number > 0_i64
+      index = number % 32_i64 # divmod is a bit slow
+      number = number >> 5    # number / 32
+      yield index
+    end
   end
 end


### PR DESCRIPTION
The idea is to compute the string bytesize by looping over the number once, and then creating a string with exactly that size, looping once more over the number:
- Looping twice is not good, but it's always faster than allocating memory
- Using `String.new` is faster than `String.build` because `String.build` uses `String::Builder` so it involves an extra allocation

I used this benchmark (I have the two implementations side-by-side to be able to compare them):

```crystal
require "benchmark"
require "./src/base32"

Benchmark.ips do |x|
  x.report("old") { Base32.encode(123456789012) }
  x.report("new") { Base32.encode_fast(123456789012) }
end
```

Results:

```
old   6.77M (147.69ns) (± 4.61%)   224B/op   7.99× slower
new  54.10M ( 18.48ns) (± 2.11%)  32.0B/op        fastest
```